### PR TITLE
[FIX] worker destroy will really stop it.

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -31,6 +31,7 @@ export default class Job extends events.EventEmitter {
     this.checkInterval = opts.interval || 1500;
     this.checkSize = opts.size || 10;
     this.doctype = opts.doctype || constants.DEFAULT_SETTING_DOCTYPE;
+    this.running = true;
 
     this.debug = (...msg) => debug(...msg, `id: ${this.id}`);
 
@@ -40,6 +41,7 @@ export default class Job extends events.EventEmitter {
   }
 
   destroy() {
+    this.running = false;
     clearInterval(this._checker);
   }
 
@@ -237,6 +239,9 @@ export default class Job extends events.EventEmitter {
   }
 
   _startJobPolling() {
+    if (!this.running) {
+      return;
+    }
     this._checker = setInterval(() => {
       this._getPendingJobs()
       .then((jobs) => this._claimPendingJobs(jobs));


### PR DESCRIPTION
Repro steps:

1. Create a Worker
2. Give it many tasks to run
3. Call Worker#destroy while its working

==! Worker doesn't stop, it keeps running.

The reason is that the Worker clears and then restarts the Interval timer while working on a Job. If you cancel the timer in the middle of a Job (say, when receiving a JOB_COMPLETE event), the timer will get re-scheduled anyway. I added the simplest fix to stop this.
