### PR TITLE
Worker destroy() will stops job polling

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -31,17 +31,17 @@ export default class Job extends events.EventEmitter {
     this.checkInterval = opts.interval || 1500;
     this.checkSize = opts.size || 10;
     this.doctype = opts.doctype || constants.DEFAULT_SETTING_DOCTYPE;
-    this.running = true;
 
     this.debug = (...msg) => debug(...msg, `id: ${this.id}`);
 
     this._checker = false;
+    this._running = true;
     this.debug(`Created worker for job type ${this.jobtype}`);
     this._startJobPolling();
   }
 
   destroy() {
-    this.running = false;
+    this._running = false;
     clearInterval(this._checker);
   }
 
@@ -239,9 +239,10 @@ export default class Job extends events.EventEmitter {
   }
 
   _startJobPolling() {
-    if (!this.running) {
+    if (!this._running) {
       return;
     }
+
     this._checker = setInterval(() => {
       this._getPendingJobs()
       .then((jobs) => this._claimPendingJobs(jobs));

--- a/src/worker.js
+++ b/src/worker.js
@@ -42,7 +42,7 @@ export default class Job extends events.EventEmitter {
 
   destroy() {
     this._running = false;
-    clearInterval(this._checker);
+    this._stopJobPolling();
   }
 
   toJSON() {

--- a/src/worker.js
+++ b/src/worker.js
@@ -31,6 +31,7 @@ export default class Job extends events.EventEmitter {
     this.checkInterval = opts.interval || 1500;
     this.checkSize = opts.size || 10;
     this.doctype = opts.doctype || constants.DEFAULT_SETTING_DOCTYPE;
+    this.running = true;
 
     this.debug = (...msg) => debug(...msg, `id: ${this.id}`);
 
@@ -40,6 +41,7 @@ export default class Job extends events.EventEmitter {
   }
 
   destroy() {
+    this.running = false;
     clearInterval(this._checker);
   }
 
@@ -237,6 +239,9 @@ export default class Job extends events.EventEmitter {
   }
 
   _startJobPolling() {
+    if (!this.running) {
+      return;
+    }
     this._checker = setInterval(() => {
       this._getPendingJobs()
       .then((jobs) => this._claimPendingJobs(jobs));

--- a/test/src/worker.js
+++ b/test/src/worker.js
@@ -185,6 +185,27 @@ describe('Worker class', function () {
       clock.tick(interval);
       sinon.assert.calledOnce(searchSpy);
     });
+
+    it('should not poll once destroyed', function () {
+      const worker = new Worker(mockQueue, 'test', noop);
+
+      // move the clock a couple times, test for searches each time
+      sinon.assert.notCalled(searchSpy);
+      clock.tick(defaults.interval);
+      sinon.assert.calledOnce(searchSpy);
+      clock.tick(defaults.interval);
+      sinon.assert.calledTwice(searchSpy);
+
+      // destroy the worker, move the clock, make sure another search doesn't happen
+      worker.destroy();
+      clock.tick(defaults.interval);
+      sinon.assert.calledTwice(searchSpy);
+
+      // manually call job poller, move the clock, make sure another search doesn't happen
+      worker._startJobPolling();
+      clock.tick(defaults.interval);
+      sinon.assert.calledTwice(searchSpy);
+    });
   });
 
   describe('query for pending jobs', function () {


### PR DESCRIPTION
Builds on https://github.com/elastic/esqueue/pull/12

- Renames the state variable, using leading `_` to indicate it's a private property
- Adds tests to ensure the worker doesn't perform searches after being destroyed